### PR TITLE
Adds support for lang in <html> header

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  i18n: {
+    locales: ['en'],
+    defaultLocale: 'en',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shadowmaru.dev.next",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Adds `next.config.js` file with locale information, to enable having `lang` in the `<html>` tag, like:

```html
<html lang="en">
```

Which is one of the accessibility verifications from Lighthouse.