### PR TITLE
fix: refactor <title> tag to remove warning

### DIFF
--- a/pages/publications.tsx
+++ b/pages/publications.tsx
@@ -7,7 +7,7 @@ export default function Publications() {
   return (
     <Layout>
       <Head>
-        <title>{siteTitle} - Publications</title>
+        <title>{`${siteTitle} - Publications`}</title>
       </Head>
       <section>
         <h2 className={utilStyles.headingLg}>Publications</h2>

--- a/pages/resume.tsx
+++ b/pages/resume.tsx
@@ -16,7 +16,7 @@ export default function Resume() {
   return (
     <Layout resume>
       <Head>
-        <title>{siteTitle} - Resume</title>
+        <title>{`${siteTitle} - Resume`}</title>
       </Head>
 
       <section className={resumeStyles.personal}>


### PR DESCRIPTION
The warning was: "Warning: A title element received an array with more than 1 element as children"