### PR TITLE
Fediverse creator metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,6 +30,9 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
   },
+  other: {
+    'fediverse:creator': `@shadowmaru@bolha.one`
+  },
   alternates: {
     types: {
       'application/rss+xml': `${siteUrl}/feed.xml`,

--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -35,6 +35,9 @@ export async function generateMetadata(
     description: post.description,
     openGraph: {
       images: [`${metadata.openGraph?.url}${post.thumbnail}`],
+    },
+    other: {
+      'fediverse:creator': post.author,
     }
   }
 }

--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -30,15 +30,21 @@ export async function generateMetadata(
 
   const post = await getPostData(id as string)
 
+  const thumbnail = post.thumbnail ? `${metadata.openGraph?.url}${post.thumbnail}` : null
+
   return {
     title: post.title,
     description: post.description,
-    openGraph: {
-      images: [`${metadata.openGraph?.url}${post.thumbnail}`],
-    },
-    other: {
-      'fediverse:creator': post.author,
-    },
+    ...(thumbnail && {
+      openGraph: {
+       images: [thumbnail],
+      }
+    }),
+    ...(post.author && {
+      other: {
+        'fediverse:creator': post.author,
+      },
+    }),
   }
 }
 

--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -38,7 +38,7 @@ export async function generateMetadata(
     },
     other: {
       'fediverse:creator': post.author,
-    }
+    },
   }
 }
 

--- a/lib/posts.tsx
+++ b/lib/posts.tsx
@@ -21,7 +21,7 @@ export function getSortedPostsData() {
 
       return {
         id,
-        ...(matterResult.data as { date: string; title: string, description: string, thumbnail: string }),
+        ...(matterResult.data as { date: string; title: string, description: string, thumbnail: string, author: string }),
       };
     });
 
@@ -61,6 +61,6 @@ export async function getPostData(id: string) {
   return {
     id,
     contentHtml,
-    ...(matterResult.data as { date: string; title: string, description: string, thumbnail: string }),
+    ...(matterResult.data as { date: string; title: string, description: string, thumbnail: string, author:string }),
   };
 }

--- a/posts/notion-for-1-1.md
+++ b/posts/notion-for-1-1.md
@@ -2,6 +2,8 @@
 title: "Using Notion for 1:1s"
 description: "Using templates and databases to keep things organized"
 date: "2021-07-17"
+author: "@shadow@hachyderm.io"
+thumbnail: "/images/posts/notion3.png"
 ---
 
 Recently I've started to hold regular 1:1s with members on my team, as part of a transition to the


### PR DESCRIPTION
- Adds a meta tag `fediverse:creator` that has a default value, but can be overwritten if there is an author cited in the post frontmatter
- Fix: replaces openGraph image only if there is a thumbnail in the post frontmatter
- Adds author and thumbnail to Notion 1:1 post